### PR TITLE
Fix Claude Code action max_turns limit for PR reviews

### DIFF
--- a/.github/workflows/claude-reusable.yml
+++ b/.github/workflows/claude-reusable.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           trigger_phrase: "@claude"
           timeout_minutes: "60"
-          max_turns: 5
+          max_turns: 10
           github_token: ${{ steps.app-token.outputs.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         env:


### PR DESCRIPTION
# Fix Claude Code action max_turns limit for PR reviews

## Problem

Claude Code action is hitting the `max_turns: 5` limit before completing PR reviews in the web-experience project. The action posts the initial task list but never provides actual review feedback, leaving all checkboxes empty.

From the action logs:

```
"subtype": "error_max_turns"
"num_turns": 5
```

Claude runs out of turns after reading the changed files but before writing and posting the review feedback.

## Solution

Increase `max_turns` from `5` to `10` in the reusable workflow. This may need further adjustment if 10 turns proves insufficient for larger PRs.

## Why this change is needed

For PR reviews, Claude typically needs:
- 1 turn: Post initial task list
- 3-4 turns: Read each changed file 
- 2-3 turns: Analyse code and write comprehensive review
- 1 turn: Update comment with final review feedback

5 turns only allows file reading, not the actual review analysis and posting.

## Impact

- PR reviews will now complete successfully with actual feedback
- No impact on simpler tasks that don't need as many turns
- Slight increase in action runtime for complex reviews (but they'll actually work)
- May need further tuning based on PR complexity
